### PR TITLE
fix(renovate-nix): lazy nix wrapper for per-invocation token injection

### DIFF
--- a/apps/renovate-nix/entrypoint.sh
+++ b/apps/renovate-nix/entrypoint.sh
@@ -1,8 +1,20 @@
 #!/usr/bin/env sh
 set -e
 
-if [ -n "$RENOVATE_TOKEN" ]; then
-    export NIX_CONFIG="access-tokens = github.com=$RENOVATE_TOKEN"
+# Install a wrapper so every nix invocation picks up RENOVATE_TOKEN from the
+# subprocess environment (Renovate injects it when running postUpgradeTasks,
+# which may be after the container starts with no token yet mounted).
+_nix_real="$(command -v nix 2>/dev/null || true)"
+if [ -n "$_nix_real" ]; then
+    _wrapper_dir="$HOME/.local/bin"
+    mkdir -p "$_wrapper_dir"
+    # $RENOVATE_TOKEN must expand at wrapper runtime, not here
+    # shellcheck disable=SC2016
+    printf '#!/bin/sh\n[ -n "${RENOVATE_TOKEN:-}" ] && export NIX_CONFIG="access-tokens = github.com=$RENOVATE_TOKEN"\nexec "%s" "$@"\n' \
+        "$_nix_real" > "$_wrapper_dir/nix"
+    chmod +x "$_wrapper_dir/nix"
+    export PATH="$_wrapper_dir:$PATH"
+    echo "[entrypoint] nix wrapper installed: token=${RENOVATE_TOKEN:+PRESENT}${RENOVATE_TOKEN:-ABSENT}"
 fi
 
 exec "$@"


### PR DESCRIPTION
## Summary

- Replaces startup-time `NIX_CONFIG` assignment with a lazy wrapper at `$HOME/.local/bin/nix` (prepended to PATH)
- The wrapper reads `RENOVATE_TOKEN` fresh on every nix invocation, so GitHub auth is available even when Renovate only injects the token into `postUpgradeTasks` subprocess environments (not at container startup)
- Logs `PRESENT`/`ABSENT` at startup without printing the token value