### PR TITLE
fix(renovate-nix): bake nix wrapper into image for operator-bypassed entrypoint

### DIFF
--- a/apps/renovate-nix/Dockerfile
+++ b/apps/renovate-nix/Dockerfile
@@ -32,8 +32,18 @@ RUN mkdir -p /etc/nix && \
 
 USER root
 
-# Set PATH to use /opt/nix location
-ENV PATH="/opt/nix/profile/bin:${PATH}"
+# Wrapper that injects RENOVATE_TOKEN into NIX_CONFIG per-invocation so GitHub
+# API calls are authenticated; baked into the image so it works even when the
+# operator runs renovate directly (bypassing ENTRYPOINT).
+RUN mkdir -p /opt/nix/wrapper && \
+    { \
+      echo '#!/bin/sh'; \
+      echo '[ -n "${RENOVATE_TOKEN:-}" ] && export NIX_CONFIG="access-tokens = github.com=$RENOVATE_TOKEN"'; \
+      echo 'exec /opt/nix/profile/bin/nix "$@"'; \
+    } > /opt/nix/wrapper/nix && \
+    chmod +x /opt/nix/wrapper/nix
+
+ENV PATH="/opt/nix/wrapper:/opt/nix/profile/bin:${PATH}"
 
 COPY --chmod=755 entrypoint.sh /entrypoint.sh
 

--- a/apps/renovate-nix/entrypoint.sh
+++ b/apps/renovate-nix/entrypoint.sh
@@ -1,8 +1,4 @@
 #!/usr/bin/env sh
 set -e
-
-if [ -n "$RENOVATE_TOKEN" ]; then
-    export NIX_CONFIG="access-tokens = github.com=$RENOVATE_TOKEN"
-fi
-
+echo "[entrypoint] token=${RENOVATE_TOKEN:+PRESENT}${RENOVATE_TOKEN:-ABSENT}"
 exec "$@"


### PR DESCRIPTION
## Summary

The Renovate operator runs `command: renovate` directly, which bypasses the image `ENTRYPOINT`. The previous approach of installing the nix wrapper in `entrypoint.sh` at runtime was never executed.

- Moves the nix wrapper creation to the Dockerfile (`RUN` step) so it's baked into `/opt/nix/wrapper/nix` at image build time
- Prepends `/opt/nix/wrapper` to `ENV PATH` so the wrapper is found regardless of how the container is started
- Simplifies `entrypoint.sh` to just log token presence and exec (the Dockerfile handles auth)

The wrapper reads `RENOVATE_TOKEN` at each nix invocation and sets `NIX_CONFIG="access-tokens = github.com=$RENOVATE_TOKEN"`, authenticating GitHub API calls (needed to fetch `github:NixOS/nixpkgs/nixpkgs-unstable` without hitting the unauthenticated rate limit).